### PR TITLE
テーマカラーを指定するCSS変数の追加

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -13,3 +13,10 @@
  *= require_tree .
  *= require_self
  */
+
+:root {
+  --main-col: #04a7ff;
+  --sub-col: #64cafd;
+  --white-col: #f9f9f9;
+  --black-col: #2b2627;
+}

--- a/app/assets/stylesheets/static_pages.scss
+++ b/app/assets/stylesheets/static_pages.scss
@@ -1,3 +1,6 @@
 // Place all the styles related to the StaticPages controller here.
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: https://sass-lang.com/
+.section {
+  background-color: var(--white-col);
+}


### PR DESCRIPTION
###WHAT
- テーマカラーを指定するCSS変数の追加

### WHY
- 色数を絞った方が画面全体として綺麗に見えるので、事前に使う色を絞っておくために変数を作成した。